### PR TITLE
Create a Contributing.md file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -9,6 +9,8 @@ size, disability, ethnicity, gender identity and expression, level of experience
 nationality, personal appearance, race, religion, or sexual identity and
 orientation.
 
+For these reasons we require each contributor to be also a public subscriber of [Code Manifesto](http://codemanifesto.com/support)
+
 ## Our Standards
 
 Examples of behavior that contributes to creating a positive environment

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [abuse@phpwomen.org](abuse@phpwomen.org). All
+reported by contacting the project team at [hello@phpwomen.org](hello@phpwomen.org). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [abuse@phpwomen.org](abuse@phpwomen.org). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ These are just guidelines, not rules, use your best judgment and feel free to pr
 
 [How Can I Contribute?](#how-can-i-contribute)
    * [Reporting Bugs](#reporting-bugs)
+   * [How To Suggest Changes or Request New Features](#how-to-suggest-changes-or-request-new-features)
    * [How To Submit Changes](#how-to-submit-changes)
       * [Pull Requests](#pull-requests)
 
@@ -50,6 +51,15 @@ Explain the problem and include additional details to help maintainers reproduce
 * **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
 * **Explain which behavior you expected to see instead and why.**
 * **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem.  You can use [this tool](http://www.cockos.com/licecap/) to record GIFs on OSX and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
+
+### How to Suggest Changes or Request New Features
+
+We warmly welcome contributions.
+
+If you have an idea for something new for the website, please create [an issue](https://github.com/phpwomen/combell/issues).  In the title of the issue please start the title with `Suggestion: `.  A contributor will comment to ask you clarifying questions and to assist you with getting the feature implemented.
+
+Requests specific to the business of the PHP Women organization should be directed to [hello@phpwomen](mailto:hello@phpwomen.org).
+
 
 ### How To Submit Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ These are just guidelines, not rules, use your best judgment and feel free to pr
   * [How the Site is Organized](#how-the-site-is-organized)
 [How Can I Contribute?](#how-can-i-contribute)
    * [Reporting Bugs](#reporting-bugs)
+   * [How To Submit Changes](#how-to-submit-changes)
+      * [Pull Requests](#pull-requests)
 
 ## What should I know before I get started?
 
@@ -47,13 +49,16 @@ Explain the problem and include additional details to help maintainers reproduce
 * **Explain which behavior you expected to see instead and why.**
 * **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem.  You can use [this tool](http://www.cockos.com/licecap/) to record GIFs on OSX and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
 
-### How People Should Work
+### How To Submit Changes
 
-New features should be added by creating a branch from master.  We prefer a naming scheme that uses the feature and issue number in the name, like `contributing-md-issue-20` or `contributing-20` or something similar.  
+New features and Bug Fixes should be added by creating a branch from master.  We prefer a naming scheme that uses the feature and/or issue number in the name, like `contributing-md-issue-20`, `contributing-20`, `issue-20`.
 
-When the feature is ready for review or requires feedback, a Pull Request should be created from the feature branch to `master`.  A pull request must be reviewed by someone who was not the author of the feature; otherwise it needs review by multiple reviewers.  As part of the review process, a reviewer should do more than look at the code changes.  They should pull the branch locally and run it on their machine to verify the code does not break another install.  This would not apply to page text changes.  
+#### Pull Requests
 
-When the feature is approved and merged, Travis CI will send the changes to the server for us. 
+* When the feature is ready for review or requires feedback, a Pull Request should be created from the feature branch to `master`.
+* A pull request must be reviewed by someone who was not the author of the feature; otherwise it needs review by multiple reviewers.  As part of the review process, a reviewer should do more than look at the code changes.  They should pull the branch locally and run it on their machine to verify the code does not break another install.  This would not apply to page text changes.
+
+When the feature is approved and the Pull Request is merged, Travis CI will send the changes to the server for us.
 
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ These are just guidelines, not rules, use your best judgment and feel free to pr
 
 This project adheres to the Contributor Covenant [code of conduct](CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code.
-Please report unacceptable behavior to [abuse@phpwomen](mailto:abuse@phpwomen.org).
+Please report unacceptable behavior to [hello@phpwomen](mailto:hello@phpwomen.org).
 
 ### How the Site is Organized
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Before creating bug reports, please check [this list](https://github.com/phpwome
 
 #### How Do I Submit A (Good) Bug Report?
 
-Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/). After you've made sure this bug hasn't been reported, create an issue and provide the following information.
+Website bugs must be reported in the Issues section of this project, here on Github. Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/). After you've made sure this bug hasn't been reported, create an issue and provide the following information.
 
 Explain the problem and include additional details to help maintainers reproduce the problem:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ These are just guidelines, not rules, use your best judgment and feel free to pr
   * [Code of Conduct](#code-of-conduct)
   * [How the Site is Organized](#how-the-site-is-organized)
 [How Can I Contribute?](#how-can-i-contribute)
+   * [Reporting Bugs](#reporting-bugs)
 
 ## What should I know before I get started?
 
@@ -26,7 +27,27 @@ We have two nearly identical websites [dev.phpwomen.org](http://dev.phpwomen.org
 
 On GitHub there are two protected branches, `master` which syncs to `dev.phpwomen.org` and `production` which syns with `phpwomen.org`.  This means that we can make changes to the site without affecting production, until we are ready to update the production web site.
 
-# How People Should Work
+## How Can I Contribute?
+
+### Reporting Bugs
+
+This section guides you through submitting a bug report for PHP Women. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
+
+Before creating bug reports, please check [this list](https://github.com/phpwomen/combell/issues) as it may have already been reported. When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). If you'd like, you can use [this template](#template-for-submitting-bug-reports) to structure the information.
+
+#### How Do I Submit A (Good) Bug Report?
+
+Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/). After you've made sure this bug hasn't been reported, create an issue and provide the following information.
+
+Explain the problem and include additional details to help maintainers reproduce the problem:
+
+* **Use a clear and descriptive title** for the issue to identify the problem.
+* **Describe the exact steps which reproduce the problem** in as many details as possible.
+* **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
+* **Explain which behavior you expected to see instead and why.**
+* **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem.  You can use [this tool](http://www.cockos.com/licecap/) to record GIFs on OSX and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
+
+### How People Should Work
 
 New features should be added by creating a branch from master.  We prefer a naming scheme that uses the feature and issue number in the name, like `contributing-md-issue-20` or `contributing-20` or something similar.  
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,9 @@
-# Contributing to PHPWomen
+# Contributing to PHP Women website
 
 :+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
 
-The following is a set of guidelines for contributing to PHP Women, which are hosted in the [PHP Women Organization](https://github.com/phpwomen/combell/) on GitHub.
+The following is a set of guidelines for contributing to [PHP Women website](https://github.com/phpwomen/combell/), which is hosted in the [PHP Women Organization](https://github.com/phpwomen/) on GitHub.
+
 These are just guidelines, not rules, use your best judgment and feel free to propose changes to this document in a pull request.
 
 #### Table Of Contents
@@ -34,7 +35,7 @@ On GitHub there are two protected branches, `master` which syncs to `dev.phpwome
 
 ### Reporting Bugs
 
-This section guides you through submitting a bug report for PHP Women. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
+This section guides you through submitting a bug report for PHP Women website. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
 
 Before creating bug reports, please check [this list](https://github.com/phpwomen/combell/issues) as it may have already been reported. When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). If you'd like, you can use [this template](#template-for-submitting-bug-reports) to structure the information.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ These are just guidelines, not rules, use your best judgment and feel free to pr
 [What should I know before I get started?](#what-should-i-know-before-i-get-started)
   * [Code of Conduct](#code-of-conduct)
   * [How the Site is Organized](#how-the-site-is-organized)
+
 [How Can I Contribute?](#how-can-i-contribute)
    * [Reporting Bugs](#reporting-bugs)
    * [How To Submit Changes](#how-to-submit-changes)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ These are just guidelines, not rules, use your best judgment and feel free to pr
 
 This project adheres to the Contributor Covenant [code of conduct](CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code.
-Please report unacceptable behavior to [hello@phpwomen](mailto:hello@phpwomen.org).
+Please report unacceptable behavior to [hello@phpwomen.org](mailto:hello@phpwomen.org).
 
 ### How the Site is Organized
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ Explain the problem and include additional details to help maintainers reproduce
 
 We warmly welcome contributions.
 
-If you have an idea for something new for the website, please create [an issue](https://github.com/phpwomen/combell/issues).  In the title of the issue please start the title with `Suggestion: `.  A contributor will comment to ask you clarifying questions and to assist you with getting the feature implemented.
+If you have an idea for something new for the website, please create [an issue](https://github.com/phpwomen/combell/issues).  In the title of the issue please start the title with `Suggestion: ` followed by a descriptive title.  A contributor will comment to ask you clarifying questions and to assist you with getting the feature implemented.
 
 Requests specific to the business of the PHP Women organization should be directed to [hello@phpwomen](mailto:hello@phpwomen.org).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,14 +56,19 @@ Explain the problem and include additional details to help maintainers reproduce
 
 We warmly welcome contributions.
 
-If you have an idea for something new for the website, please create [an issue](https://github.com/phpwomen/combell/issues).  In the title of the issue please start the title with `Suggestion: ` followed by a descriptive title.  A contributor will comment to ask you clarifying questions and to assist you with getting the feature implemented.
+If you have an idea for something new for the website, please create [an issue](https://github.com/phpwomen/combell/issues).  Give the issue a descriptive title that tells the problem you want to solve.  Please use a label to tag your suggestion as `enhancement` or `question`.  A contributor will comment to ask you clarifying questions and to assist you with getting the feature ready to be implemented.  If you would like to make the contribution, you will be able to do that.
 
-Requests specific to the business of the PHP Women organization should be directed to [hello@phpwomen](mailto:hello@phpwomen.org).
+Requests specific to the business of the PHP Women organization should be directed to [hello@phpwomen.org](mailto:hello@phpwomen.org).
 
 
 ### How To Submit Changes
 
-New features and Bug Fixes should be added by creating a branch from master.  We prefer a naming scheme that uses the feature and/or issue number in the name, like `contributing-md-issue-20`, `contributing-20`, `issue-20`.
+We are so excited to have your help!
+
+Issues tagged with the label `Help Wanted` that aren't assigned to anyone, are available to be worked on. If an issue has gone quiet, we welcome you to comment and wake it up.
+
+New features and Bug Fixes should be added by creating a branch from master.  We prefer naming branches by using the feature and/or issue number in the name, like `contributing-md-issue-20`, `contributing-20`, `issue-20`.
+
 
 #### Pull Requests
 
@@ -71,6 +76,3 @@ New features and Bug Fixes should be added by creating a branch from master.  We
 * A pull request must be reviewed by someone who was not the author of the feature; otherwise it needs review by multiple reviewers.  As part of the review process, a reviewer should do more than look at the code changes.  They should pull the branch locally and run it on their machine to verify the code does not break another install.  This would not apply to page text changes.
 
 When the feature is approved and the Pull Request is merged, Travis CI will send the changes to the server for us.
-
-
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Contributing to PHPWomen
+# Contributing to PHP Women website
 
 :+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
 
-The following is a set of guidelines for contributing to PHP Women, which are hosted in the [PHP Women Organization](https://github.com/phpwomen/combell/) on GitHub.
+The following is a set of guidelines for contributing to [PHP Women website](https://github.com/phpwomen/combell/), which is hosted in the [PHP Women Organization](https://github.com/phpwomen/) on GitHub.
 These are just guidelines, not rules, use your best judgment and feel free to propose changes to this document in a pull request.
 
 #### Table Of Contents
@@ -34,7 +34,7 @@ On GitHub there are two protected branches, `master` which syncs to `dev.phpwome
 
 ### Reporting Bugs
 
-This section guides you through submitting a bug report for PHP Women. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
+This section guides you through submitting a bug report for PHP Women website. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
 
 Before creating bug reports, please check [this list](https://github.com/phpwomen/combell/issues) as it may have already been reported. When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). If you'd like, you can use [this template](#template-for-submitting-bug-reports) to structure the information.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,26 @@
-# How the Site is Organized
+# Contributing to PHPWomen
+
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+
+The following is a set of guidelines for contributing to PHP Women, which are hosted in the [PHP Women Organization](https://github.com/phpwomen/combell/) on GitHub.
+These are just guidelines, not rules, use your best judgment and feel free to propose changes to this document in a pull request.
+
+#### Table Of Contents
+
+[What should I know before I get started?](#what-should-i-know-before-i-get-started)
+  * [Code of Conduct](#code-of-conduct)
+  * [How the Site is Organized](#how-the-site-is-organized)
+[How Can I Contribute?](#how-can-i-contribute)
+
+## What should I know before I get started?
+
+### Code of Conduct
+
+This project adheres to the Contributor Covenant [code of conduct](CODE_OF_CONDUCT.md).
+By participating, you are expected to uphold this code.
+Please report unacceptable behavior to [abuse@phpwomen](mailto:abuse@phpwomen.org).
+
+### How the Site is Organized
 
 We have two nearly identical websites [dev.phpwomen.org](http://dev.phpwomen.org) and [phpwomen.org](http://phpwomen.org).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# How the Site is Organized
+
+We have two nearly identical websites [dev.phpwomen.org](http://dev.phpwomen.org) and [phpwomen.org](http://phpwomen.org).
+
+On GitHub there are two protected branches, `master` which syncs to `dev.phpwomen.org` and `production` which syns with `phpwomen.org`.  This means that we can make changes to the site without affecting production, until we are ready to update the production web site.
+
+# How People Should Work
+
+New features should be added by creating a branch from master.  We prefer a naming scheme that uses the feature and issue number in the name, like `contributing-md-issue-20` or `contributing-20` or something similar.  
+
+When the feature is ready for review or requires feedback, a Pull Request should be created from the feature branch to `master`.  A pull request must be reviewed by someone who was not the author of the feature; otherwise it needs review by multiple reviewers.  As part of the review process, a reviewer should do more than look at the code changes.  They should pull the branch locally and run it on their machine to verify the code does not break another install.  This would not apply to page text changes.  
+
+When the feature is approved and merged, Travis CI will send the changes to the server for us. 
+
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Please report unacceptable behavior to [hello@phpwomen](mailto:hello@phpwomen.or
 
 We have two nearly identical websites [dev.phpwomen.org](http://dev.phpwomen.org) and [phpwomen.org](http://phpwomen.org).
 
-On GitHub there are two protected branches, `master` which syncs to `dev.phpwomen.org` and `production` which syns with `phpwomen.org`.  This means that we can make changes to the site without affecting production, until we are ready to update the production web site.
+On GitHub there are two protected branches, `master` which syncs to `dev.phpwomen.org` and `production` which syncs with `phpwomen.org`.  This means that we can make changes to the site without affecting production, until we are ready to update the production web site.
 
 ## How Can I Contribute?
 

--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@ form inputs on focus state need to  border orange.
 
 Supporting you in your code adventures. needs context : chat ( irc), google groups and social media.
 
+
+
+[![Join the chat at https://gitter.im/phpwomen/combell](https://badges.gitter.im/phpwomen/combell.svg)](https://gitter.im/phpwomen/combell?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)


### PR DESCRIPTION
This PR addresses some of the to-do items in #20 

I looked up a few nicely-formatted Contributing file formats.  In addition to the details we described about the contributing workflow, they included contributing code of conduct along with information about how to report bugs and formatting the code.  

I have included the latest Contributors Covenant as an example of where that could go.  I am open to using another version or an abbreviated piece of this. But need some feedback from @phpwomen/github-admins 

I added some details about how to report bugs, mostly giving ideas of how to make the issue more understandable/reproducible.  I think these sorts of prompts are helpful reminders to people submitting issues to provide more than a brief description of a problem.
